### PR TITLE
fix: #84 - prevent prefix matches in php namespace refactors

### DIFF
--- a/src/app/services/update/ClassNameUpdater.ts
+++ b/src/app/services/update/ClassNameUpdater.ts
@@ -1,4 +1,4 @@
-import { PHP_CLASS_DECLARATION_REGEX } from '@domain/namespace/PhpPatterns';
+import { NOT_FOLLOWED_BY_NAMESPACE_CHAR, NOT_PRECEDED_BY_NAMESPACE_CHAR, PHP_CLASS_DECLARATION_REGEX } from '@domain/namespace/PhpPatterns';
 import { WorkspacePathResolver } from '@domain/workspace/WorkspacePathResolver';
 import { FileEditApplier } from '@infra/vscode/FileEditApplier';
 import { TextDocumentOpener } from '@infra/vscode/TextDocumentOpener';
@@ -32,7 +32,10 @@ export class ClassNameUpdater {
       return;
     }
 
-    const newText = text.replace(new RegExp(`\\b${currentName}\\b`, 'g'), expectedName);
+    const newText = text.replace(
+      new RegExp(`${NOT_PRECEDED_BY_NAMESPACE_CHAR}${currentName}${NOT_FOLLOWED_BY_NAMESPACE_CHAR}`, 'g'),
+      expectedName,
+    );
 
     const edit = new WorkspaceEdit();
     edit.replace(

--- a/src/app/services/update/MultiFileReferenceUpdater.ts
+++ b/src/app/services/update/MultiFileReferenceUpdater.ts
@@ -1,4 +1,5 @@
 import { ImportRemover } from '@app/services/remove/ImportRemover';
+import { NOT_FOLLOWED_BY_NAMESPACE_CHAR, NOT_PRECEDED_BY_NAMESPACE_CHAR } from '@domain/namespace/PhpPatterns';
 import { UseStatementCreator } from '@domain/namespace/UseStatementCreator';
 import { UseStatementInjector } from '@domain/namespace/UseStatementInjector';
 import { UseStatementLocator } from '@domain/namespace/UseStatementLocator';
@@ -47,10 +48,10 @@ export class MultiFileReferenceUpdater {
     const newClassName = this.workspacePathResolver.extractClassNameFromPath(newUri.fsPath);
     const useImport = this.useStatementCreator.single({ fullNamespace: useNewNamespace });
     const ignoreFile = newUri.fsPath;
-    const namespaceRegex = new RegExp(this.escapeRegex(useOldNamespace), 'g');
+    const namespaceRegex = new RegExp(`${this.escapeRegex(useOldNamespace)}${NOT_FOLLOWED_BY_NAMESPACE_CHAR}`, 'g');
 
     const classNameRegex = className !== newClassName
-      ? new RegExp(`\\b${className}\\b`, 'g')
+      ? new RegExp(`${NOT_PRECEDED_BY_NAMESPACE_CHAR}${className}${NOT_FOLLOWED_BY_NAMESPACE_CHAR}`, 'g')
       : null;
 
     // Files that import/use the old namespace.

--- a/src/domain/namespace/PhpPatterns.ts
+++ b/src/domain/namespace/PhpPatterns.ts
@@ -20,3 +20,11 @@ export const PHP_CLASS_DECLARATION_REGEX = new RegExp(
   `^\\s*${DECLARATION_MODIFIER_PATTERN}(?:${NAMED_TYPE_PATTERN})\\s+(\\w+)`,
   'm'
 );
+
+// A namespace/identifier boundary: neither an identifier character (letter,
+// digit, underscore) nor a namespace separator (\) can sit on this side of a
+// match, otherwise the match is actually a prefix or suffix of a longer FQCN
+// rather than the identifier itself — e.g. matching "Foo" inside "FooBar" or
+// inside "Foo\Bar\Baz" (a sub-namespace that merely starts with "Foo").
+export const NOT_PRECEDED_BY_NAMESPACE_CHAR = '(?<![A-Za-z0-9_\\\\])';
+export const NOT_FOLLOWED_BY_NAMESPACE_CHAR = '(?![A-Za-z0-9_\\\\])';

--- a/src/domain/namespace/UnusedImportDetector.ts
+++ b/src/domain/namespace/UnusedImportDetector.ts
@@ -1,5 +1,7 @@
 import { injectable } from 'tsyringe';
 
+import { NOT_FOLLOWED_BY_NAMESPACE_CHAR, NOT_PRECEDED_BY_NAMESPACE_CHAR } from './PhpPatterns';
+
 interface Props {
   contentDocument: string,
   classes: string[],
@@ -11,7 +13,7 @@ export class UnusedImportDetector {
     const classesUsed: string[] = [];
 
     classes.forEach(className => {
-      const regex = new RegExp(`\\b${className}\\b`, 'g');
+      const regex = new RegExp(`${NOT_PRECEDED_BY_NAMESPACE_CHAR}${className}${NOT_FOLLOWED_BY_NAMESPACE_CHAR}`, 'g');
       if (regex.test(contentDocument) && !classesUsed.includes(className)) {
         classesUsed.push(className);
       }

--- a/src/test/ClassNameUpdater.test.ts
+++ b/src/test/ClassNameUpdater.test.ts
@@ -116,4 +116,42 @@ suite('ClassNameUpdater', () => {
     const text = await waitForText(uri, t => t.includes('OutroTest.class'));
     assert.ok(text.includes('class OutroTest.class'), `expected today's known-bad output, got:\n${text}`);
   });
+
+  /**
+   * A class can share its name with a sibling namespace (e.g. a
+   * RenamedClass.php file next to a RenamedClass/ directory holding
+   * Foo/Type.php). When RenamedClass.php is renamed to
+   * RenamedClassTest.php, its own aliased imports from that sibling
+   * namespace must not be corrupted just because they start with the old name.
+   */
+  test('does not corrupt its own aliased imports from a sub-namespace sharing its name', async () => {
+    const content = [
+      '<?php',
+      '',
+      'namespace App\\Controller;',
+      '',
+      'use App\\Controller\\RenamedClass\\Foo\\Type as FooType;',
+      'use App\\Controller\\RenamedClass\\Bar\\Type as BarType;',
+      '',
+      'class RenamedClass',
+      '{',
+      '}',
+      '',
+    ].join('\n');
+
+    const uri = await writeTempPhpFile('RenamedClassTest.php', content);
+    const updater = buildUpdater([]);
+
+    await updater.execute({ newUri: uri });
+
+    const text = await waitForText(uri, t => t.includes('class RenamedClassTest'));
+    assert.ok(
+      text.includes('use App\\Controller\\RenamedClass\\Foo\\Type as FooType;'),
+      `aliased sub-namespace import should be left untouched, got:\n${text}`,
+    );
+    assert.ok(
+      text.includes('use App\\Controller\\RenamedClass\\Bar\\Type as BarType;'),
+      `aliased sub-namespace import should be left untouched, got:\n${text}`,
+    );
+  });
 });

--- a/src/test/MultiFileReferenceUpdater.test.ts
+++ b/src/test/MultiFileReferenceUpdater.test.ts
@@ -239,4 +239,67 @@ suite('MultiFileReferenceUpdater', () => {
     );
     assert.ok(!/\bprivate Order \$order\b/.test(text), `old bare class name should be gone, got:\n${text}`);
   });
+
+  /**
+   * A class can share its name with a sibling namespace (e.g. a
+   * RevisaoCadastral.php file next to a RevisaoCadastral/ directory holding
+   * DadosPessoais/FormType.php and Endereco/FormType.php). Renaming the class
+   * to RevisaoCadastralTeste must not corrupt aliased imports that merely
+   * start with the old FQCN but actually point into that sibling namespace.
+   */
+  test('renaming a class does not corrupt aliased imports from a sub-namespace sharing its name', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'php-namespace-refactor-'));
+
+    const oldUri = vscode.Uri.file(path.join(dir, 'RevisaoCadastral.php'));
+    const newUri = vscode.Uri.file(path.join(dir, 'RevisaoCadastralTeste.php'));
+
+    const consumerContent = [
+      '<?php',
+      '',
+      'namespace App\\Controller\\PreCadastro\\Atendimento;',
+      '',
+      'use App\\Controller\\PreCadastro\\Atendimento\\RevisaoCadastral;',
+      'use App\\Controller\\PreCadastro\\Atendimento\\RevisaoCadastral\\DadosPessoais\\FormType as DadosPessoaisFormType;',
+      'use App\\Controller\\PreCadastro\\Atendimento\\RevisaoCadastral\\Endereco\\FormType as EnderecoFormType;',
+      '',
+      'class RevisaoCadastralController',
+      '{',
+      '    private RevisaoCadastral $revisaoCadastral;',
+      '}',
+      '',
+    ].join('\n');
+    const consumerUri = await writeTempPhpFile(dir, 'RevisaoCadastralController.php', consumerContent);
+
+    const namespaceIndex = new NamespaceIndex(os.tmpdir());
+    namespaceIndex.parseAndAdd(consumerUri.fsPath, consumerContent);
+
+    const updater = buildUpdater(namespaceIndex);
+
+    await updater.execute({
+      useOldNamespace: 'App\\Controller\\PreCadastro\\Atendimento\\RevisaoCadastral',
+      useNewNamespace: 'App\\Controller\\PreCadastro\\Atendimento\\RevisaoCadastralTeste',
+      newUri,
+      oldUri,
+    });
+
+    const document = await vscode.workspace.openTextDocument(consumerUri);
+    const text = document.getText();
+
+    assert.ok(
+      text.includes('use App\\Controller\\PreCadastro\\Atendimento\\RevisaoCadastralTeste;'),
+      `the exact FQCN import should be renamed, got:\n${text}`,
+    );
+    assert.ok(
+      text.includes('private RevisaoCadastralTeste $revisaoCadastral;'),
+      `the bare class name usage should be renamed, got:\n${text}`,
+    );
+    assert.ok(
+      text.includes('use App\\Controller\\PreCadastro\\Atendimento\\RevisaoCadastral\\DadosPessoais\\FormType as DadosPessoaisFormType;'),
+      `the aliased sub-namespace import should be left untouched, got:\n${text}`,
+    );
+    assert.ok(
+      text.includes('use App\\Controller\\PreCadastro\\Atendimento\\RevisaoCadastral\\Endereco\\FormType as EnderecoFormType;'),
+      `the aliased sub-namespace import should be left untouched, got:\n${text}`,
+    );
+  });
 });

--- a/src/test/PhpPatterns.test.ts
+++ b/src/test/PhpPatterns.test.ts
@@ -1,6 +1,10 @@
 import * as assert from 'assert';
 
-import { PHP_CLASS_DECLARATION_REGEX } from '../domain/namespace/PhpPatterns';
+import {
+  NOT_FOLLOWED_BY_NAMESPACE_CHAR,
+  NOT_PRECEDED_BY_NAMESPACE_CHAR,
+  PHP_CLASS_DECLARATION_REGEX,
+} from '../domain/namespace/PhpPatterns';
 
 suite('PHP_CLASS_DECLARATION_REGEX', () => {
   /**
@@ -76,6 +80,76 @@ suite('PHP_CLASS_DECLARATION_REGEX', () => {
       const match = PHP_CLASS_DECLARATION_REGEX.exec(content);
       assert.ok(match);
       assert.strictEqual(match[1], 'Real');
+    });
+  });
+});
+
+suite('NOT_PRECEDED_BY_NAMESPACE_CHAR / NOT_FOLLOWED_BY_NAMESPACE_CHAR', () => {
+  /**
+   * Bug – a class "RevisaoCadastral" can coexist with a sibling namespace of
+   * the same name (e.g. a RevisaoCadastral.php file next to a
+   * RevisaoCadastral/ directory). Renaming the class to "RevisaoCadastralTeste"
+   * must not corrupt aliased imports from that sibling namespace, such as
+   * "use ...\RevisaoCadastral\DadosPessoais\FormType as DadosPessoaisFormType;",
+   * because "RevisaoCadastral" there is a namespace segment, not the class.
+   */
+  function buildGuardedRegex(identifier: string): RegExp {
+    return new RegExp(`${NOT_PRECEDED_BY_NAMESPACE_CHAR}${identifier}${NOT_FOLLOWED_BY_NAMESPACE_CHAR}`, 'g');
+  }
+
+  suite('Guard against matching an identifier that is a namespace-path prefix of a longer one', () => {
+    test('replaces the identifier when it stands alone as a full FQCN', () => {
+      const regex = buildGuardedRegex('App\\\\Controller\\\\Atendimento\\\\RevisaoCadastral');
+      const content = 'use App\\Controller\\Atendimento\\RevisaoCadastral;';
+
+      const result = content.replace(regex, 'App\\Controller\\Atendimento\\RevisaoCadastralTeste');
+
+      assert.strictEqual(result, 'use App\\Controller\\Atendimento\\RevisaoCadastralTeste;');
+    });
+
+    test('does not touch aliased imports from a deeper sub-namespace sharing the same prefix', () => {
+      const regex = buildGuardedRegex('RevisaoCadastral');
+      const content = [
+        'use App\\Controller\\Atendimento\\RevisaoCadastral\\DadosPessoais\\FormType as DadosPessoaisFormType;',
+        'use App\\Controller\\Atendimento\\RevisaoCadastral\\Endereco\\FormType as EnderecoFormType;',
+      ].join('\n');
+
+      const result = content.replace(regex, 'RevisaoCadastralTeste');
+
+      assert.strictEqual(result, content, `sub-namespace imports should be left untouched, got:\n${result}`);
+    });
+
+    test('still replaces the bare identifier when it is not part of a namespace path', () => {
+      const regex = buildGuardedRegex('RevisaoCadastral');
+      const content = 'private RevisaoCadastral $revisaoCadastral;\n\nnew RevisaoCadastral();';
+
+      const result = content.replace(regex, 'RevisaoCadastralTeste');
+
+      assert.strictEqual(
+        result,
+        'private RevisaoCadastralTeste $revisaoCadastral;\n\nnew RevisaoCadastralTeste();',
+      );
+    });
+
+    test('does not match a suffix identifier that merely starts with the same characters', () => {
+      const regex = buildGuardedRegex('RevisaoCadastral');
+      const content = 'use App\\Domain\\RevisaoCadastralAbstract;';
+
+      const result = content.replace(regex, 'RevisaoCadastralTeste');
+
+      assert.strictEqual(result, content);
+    });
+
+    test('without the guard, the old regex would corrupt the sub-namespace imports (regression check)', () => {
+      const unguardedRegex = new RegExp('RevisaoCadastral', 'g');
+      const content = 'use App\\Controller\\Atendimento\\RevisaoCadastral\\DadosPessoais\\FormType as DadosPessoaisFormType;';
+
+      const result = content.replace(unguardedRegex, 'RevisaoCadastralTeste');
+
+      assert.strictEqual(
+        result,
+        'use App\\Controller\\Atendimento\\RevisaoCadastralTeste\\DadosPessoais\\FormType as DadosPessoaisFormType;',
+      );
     });
   });
 });

--- a/src/test/UnusedImportDetector.test.ts
+++ b/src/test/UnusedImportDetector.test.ts
@@ -110,5 +110,25 @@ suite('UnusedImportDetector', () => {
       const result = detector.execute({ contentDocument: content, classes: ['UserService'] });
       assert.strictEqual(result.length, 1);
     });
+
+    /**
+     * A class can share its name with a sibling namespace (e.g. a
+     * RevisaoCadastral.php file next to a RevisaoCadastral/ directory). An
+     * aliased import from that sibling namespace, such as
+     * "use ...\RevisaoCadastral\DadosPessoais\FormType as DadosPessoaisFormType;",
+     * must not make "RevisaoCadastral" look used — it's a namespace segment
+     * there, not a reference to the class.
+     */
+    test('does not treat a class name as used merely because it prefixes a sub-namespace path', () => {
+      const content = [
+        'namespace App\\Controller\\PreCadastro\\Atendimento;',
+        'use App\\Controller\\PreCadastro\\Atendimento\\RevisaoCadastral\\DadosPessoais\\FormType as DadosPessoaisFormType;',
+        'use App\\Controller\\PreCadastro\\Atendimento\\RevisaoCadastral\\Endereco\\FormType as EnderecoFormType;',
+        'class Foo { function bar(DadosPessoaisFormType $f) {} }',
+      ].join('\n');
+
+      const result = detector.execute({ contentDocument: content, classes: ['RevisaoCadastral'] });
+      assert.deepStrictEqual(result, []);
+    });
   });
 });


### PR DESCRIPTION
#84

Use namespace-aware regex boundaries when renaming classes and scanning imports so sub-namespace paths are not mistaken for the class itself. This avoids corrupting aliased imports that share a name prefix with the renamed class.